### PR TITLE
Added vertical-align styles.

### DIFF
--- a/scss/_vertical-align.scss
+++ b/scss/_vertical-align.scss
@@ -1,0 +1,32 @@
+/*
+  How I came to add this...
+  Well, the library as a whole is an accumulative work, so as I need something, I add it.
+  I noticed that some spans in a div with the `dib` class were adding height to the parent div.
+  The solution (https://bit.ly/2UvqZH4) was to add vertical-align to the spans.
+  https://bit.ly/2Jt9Asq - shows the effects of all the vertical-align values.
+*/
+
+$vertical-aligns: (
+  base baseline,
+  t top,
+  m middle,
+  b bottom,
+  s sub,
+  tt text-top,
+);
+
+@each $va in $vertical-aligns {
+  $alias: nth($va, 1);
+  $value: nth($va, 2);
+
+  .va-#{$alias} { vertical-align: #{$value}; }
+
+  @each $breakpoint in $breakpoints {
+    $bp: nth($breakpoint, 1);
+    $letters: nth($breakpoint, 2);
+
+    @media #{$bp} {
+      .va-#{$alias}-#{$letters} { vertical-align: #{$value}; }
+    }
+  }
+}

--- a/scss/sassyons.scss
+++ b/scss/sassyons.scss
@@ -29,5 +29,6 @@ body {
 @import './shades';
 @import './spacing';
 @import './text';
+@import './vertical-align';
 @import './width';
 @import './z-index';


### PR DESCRIPTION
How I came to add this...

The library as a whole is an accumulative work, so as I need something, I add it. I noticed that some spans in a div with the `dib` (`display: inline-block`) class were adding height to the parent div. The solution (https://bit.ly/2UvqZH4) was to add vertical-align to the spans.

https://bit.ly/2Jt9Asq - shows the effects of all the vertical-align values.